### PR TITLE
update from upstream

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye@sha256:6a90fc943f0edef4aa059d6fa8a59747f02c589a142368462a2c06f51ab9ee32
+FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye@sha256:a429f262b5b98dd7fa7ab782610da49b6853af9d9909521b80e56b46577e4e6f
 
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,9 +245,6 @@ jobs:
   cargo-test-and-report:
     name: Cargo test (and report)
     runs-on: ubuntu-latest
-    needs:
-      - changes
-    if: fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.69.0**
- **chore(deps): update github/codeql-action action to v3.25.1**
- **chore(deps): update actions/download-artifact action to v4.1.5**
- **chore(deps): update actions/upload-artifact action to v4.3.2**
- **chore(deps): update rust:1.77.2 docker digest to 5cff578**
- **chore(deps): update rust:1.77.2 docker digest to 6052afe**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/checkout action to v4.1.3**
- **chore(deps): update actions/upload-artifact action to v4.3.3**
- **chore(deps): update actions/download-artifact action to v4.1.6**
- **chore(deps): update github/codeql-action action to v3.25.2**
- **chore(deps): update actions/download-artifact action to v4.1.7**
- **chore(deps): update rust:1.77.2 docker digest to 76b4fd3**
- **chore(deps): update returntocorp/semgrep docker tag to v1.70.0**
- **chore(deps): update rust:1.77.2 docker digest to 660454d**
- **chore(deps): update rust:1.77.2 docker digest to 8824f00**
- **chore(deps): update rust:1.77.2 docker digest to 491c4b7**
- **chore(deps): update actions/checkout action to v4.1.4**
- **chore(deps): update npm to >=10.6.0**
- **chore(deps): update github/codeql-action action to v3.25.3**
- **chore(deps): update rust:1.77.2 docker digest to 8f891e6**
- **chore(deps): lock file maintenance**
- **chore: always run reporting, even when no changes as reports are mandatory**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to a429f26**
